### PR TITLE
Modification pour ajouter les transcrits des images

### DIFF
--- a/FRENCH_TRAD_NOTES.md
+++ b/FRENCH_TRAD_NOTES.md
@@ -70,7 +70,7 @@ Cela devrait être fait dès que possible en repérant les expressions spécifiq
 TODO On May 4th: get last updates from nickys project and stop at this version.
 
 ## Traduire /pics
-- retrouver les polices utilisées dans les images (contacter nicky si besoin)
+- retrouver les polices utilisées dans les images (nicky a été contacté, suivre la demande https://github.com/ncase/covid-19/issues/15)
 - rédiger les traductions dans le fichier [pics/PICS_TRANSLATION.md](pics/PICS_TRANSLATION.md), et les valider, avant de les appliquer dans les images 
 
 |   |  Traduit | Relu  | Appliqué à l'image |

--- a/pics/PICS_TRANSLATION.md
+++ b/pics/PICS_TRANSLATION.md
@@ -1,8 +1,15 @@
 # Traduction des images
 
+Les mots en italiques sont respectés avec l'utilisation de la syntaxe mardown.
+
+Pour des images multi paneaux, les paneaux sont listés.
+
+Souvent les dessins contiennent du texte en majuscule, en plus des légendes. La traduction est facile, mais le texte est ajouté pour se rappeler de le modifier dans les images.
+
+
 |   |  Police | Texte original  | Traduction |
 |---|---|------|---|
-| [dp3t.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/dp3t.png) |  |  |   | 
+| [dp3t.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/dp3t.png)|  | X |   | 
 | [exponential.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/exponential.png) | |   |   | 
 | [graphs_q.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/graphs_q.png) |  |    |   | 
 | [masks.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/masks.png) | |  |   | 
@@ -23,3 +30,43 @@
 
 ##  Polices
 *Ajoutez des liens pour télécharger les polices ici si besoin*
+
+## [DP3T](https://raw.githubusercontent.com/ncase/covid-19/master/pics/dp3t.png)
+
+### Original text
+
+How privacy-first contact tracing works
+
+1. 
+* Alice's phone broadcasts a random message every few minutes.
+2. 
+* COUGH
+* Alice sits next to Bob. Their phones exchange messages.
+3. 
+* WHAT I SAID
+* WHAT I HEARD
+* Both phones remember what they said and heard in the past 14 days.
+4.
+* WHAT I SAID
+* If Alice gets Covid-19, she sends <em>her</em> messages to a hospital.
+5. 
+* WHAT COVID-19 CASES SAID
+* Because the messages are random, no info's revealed to the hospital...
+6.
+* WHAT COVID-19 CASES SAID
+* WHAT I HEARD
+* ... but Bob's phone can find out if it "heard" any messages from Covid-19 cases!
+7.
+* If it "heard" enough messages, meaning Bob was exposed for a long enough time, he'll be alerted.
+8. 
+* And that's how contact tracing can protect our health <em>and</em> privacy!
+
+### Texte traduit
+
+## [exponential.png](https://raw.githubusercontent.com/ncase/covid-19/master/pics/exponential.png)
+
+### Original text
+
+### Texte traduit
+
+*Ajoutez au fur et à mesure les images transcrites et traduites*


### PR DESCRIPTION
Hello, 

J'ai retranscrit une image (wouhou!), et en fait il y a pas mal de texte, donc ça ne tient pas facilement dans un tableau markdown. J'ai donc modifié le document de travail sur les images de façon à mettre du texte plus facilement.

Pas de traduction d'image pour le moment.

J'ai aussi mentionné l'issue pour demander la police utilisée dans les images. 